### PR TITLE
Change to always return warmup period when save_warmup is TRUE

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -266,11 +266,14 @@ stan_sample <- function(fn, par_inits = NULL, n_pars = NULL, additional_args = l
   par_vars <- draw_names[!(draw_names %in% diagnostic_vars)]
   draws <- posterior::as_draws_df(do.call(rbind.data.frame, draws))
   diagnostics <- posterior::subset_draws(draws, variable = diagnostic_vars)
-  if (isTRUE(save_warmup)) {
-    diagnostics <- diagnostics[diagnostics$.iteration > num_warmup, ]
-  }
+
   if (check_diagnostics) {
+    if (isTRUE(save_warmup)) {
+      check_hmc_diagnostics(diagnostics[diagnostics$.iteration > num_warmup, ],
+                            as.numeric(metadata$max_depth))
+    } else {
     check_hmc_diagnostics(diagnostics, as.numeric(metadata$max_depth))
+    }
   }
 
   methods::new("StanMCMC",


### PR DESCRIPTION
You previously commited [this change](https://github.com/andrjohns/StanEstimators/commit/0f637993eb564ecd1fa94ad2e810afa100269b6d) to fix a bug I reported in [this issue](https://github.com/andrjohns/StanEstimators/issues/25). The main issue was fixed but it introduced a new bug.

When the user sets `save_warmup=TRUE` the diagnostic output gets trimmed, which is correct for checking diagnostics, but it then returns that. So downstream the user cannot look at the sampler parameters during the warmup. This e.g., breaks a link to something like ShinyStan. It is also unexpected from a user perspective that `save_warmup` does not control whether the warmup samples are saved.

This PR just moves the filtering of warmup samples when calling `check_hmc_diagnostics`. 

It passes tests locally. A quick reprex from the README shows the behavior:

````
fit1 <- stan_sample(loglik_fun, inits, additional_args = list(y),
                   lower = c(-Inf, 0), # Enforce a positivity constraint for SD
                   num_chains = 1, seed = 1234, save_warmup=TRUE)
fit1@diagnostics |> nrow()

fit2 <- stan_sample(loglik_fun, inits, additional_args = list(y),
                    lower = c(-Inf, 0), # Enforce a positivity constraint for SD
                    num_chains = 1, seed = 1234, save_warmup=FALSE)
fit2@diagnostics |> nrow()
````

Where the first has 2000 rows and the second 1000 rows.