### PR TITLE
Update check_hmc_diagnostic function

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -266,11 +266,14 @@ stan_sample <- function(fn, par_inits = NULL, n_pars = NULL, additional_args = l
   par_vars <- draw_names[!(draw_names %in% diagnostic_vars)]
   draws <- posterior::as_draws_df(do.call(rbind.data.frame, draws))
   diagnostics <- posterior::subset_draws(draws, variable = diagnostic_vars)
-  if (isTRUE(save_warmup)) {
-    diagnostics <- diagnostics[diagnostics$.iteration > num_warmup, ]
-  }
+
   if (check_diagnostics) {
+    if (isTRUE(save_warmup)) {
+      check_hmc_diagnostics(diagnostics[diagnostics$.iteration > num_warmup, ],
+                            as.numeric(metadata$max_depth))
+    } else {
     check_hmc_diagnostics(diagnostics, as.numeric(metadata$max_depth))
+    }
   }
 
   methods::new("StanMCMC",

--- a/R/util.R
+++ b/R/util.R
@@ -503,12 +503,12 @@ match_draws_format <- function(reference_draws, draws) {
   to_draws_format(draws, reference_format)
 }
 
-check_hmc_diagnostics <- function(draws_df, max_treedepth) {
+check_hmc_diagnostics <- function(draws_df, max_treedepth, print=TRUE) {
   num_draws <- nrow(draws_df)
   n_divergent <- sum(draws_df$divergent__)
   perc_divergent <- round(100 * n_divergent / num_draws, 2)
 
-  if (n_divergent > 0) {
+  if (n_divergent > 0 & print) {
     message(
       n_divergent, " of ", num_draws, " (", perc_divergent, "%)",
       " sampling iterations ended with a divergence.\n",
@@ -518,10 +518,10 @@ check_hmc_diagnostics <- function(draws_df, max_treedepth) {
       "If this doesn't remove all divergences, try to reparameterize the model.")
   }
 
-  max_treedepths <- sum(draws_df$treedepth__ > max_treedepth)
+  max_treedepths <- sum(draws_df$treedepth__ >= max_treedepth)
   perc_treedepth <- round(100 * max_treedepths / num_draws, 2)
 
-  if (max_treedepths > 0) {
+  if (max_treedepths > 0 & print) {
     message(
       max_treedepths, " of ", num_draws, " (", perc_treedepth, "%)",
       " transitions hit the maximum treedepth limit of ", max_treedepth,
@@ -538,7 +538,7 @@ check_hmc_diagnostics <- function(draws_df, max_treedepth) {
 
   num_below_threshold <- sum(ebfmi_thresholds_by_chain)
 
-  if (num_below_threshold > 0) {
+  if (num_below_threshold > 0 & print) {
     message(
       num_below_threshold, " of ", length(ebfmi_thresholds_by_chain),
       " chains had an E-BFMI below the nominal threshold of 0.3 which ",
@@ -546,5 +546,8 @@ check_hmc_diagnostics <- function(draws_df, max_treedepth) {
       "If possible, try to reparameterize the model."
     )
   }
-  invisible(NULL)
+  out <- data.frame(perc_divergent=perc_divergent,
+                    perc_treedepth=perc_treedepth,
+                    num_below_threshold=num_below_threshold)
+  invisible(out)
 }


### PR DESCRIPTION
This PR fixes a small bug in the `check_hmc_diagnostics` function where the number of iterations exceeding the treedepth was calculated as

`max_treedepths <- sum(draws_df$treedepth__ > max_treedepth)`

but should be

`max_treedepths <- sum(draws_df$treedepth__ >= max_treedepth)`

The sampler will never exceed the max_treedepth so perhaps `==` would be more sensible. Furthermore it adds a new `print=TRUE` argument to toggle console printing, and instead of returning nothing it returns a data.frame containing the percent divergences, number of treedepth exceedences, and EBMFI info. These two are useful for users running a lot of models and wanting an easy way to track this diagnostic information. I would suggest exporting this function as well, as a user may want to rerun it (e.g., in a saved session). 

Reprex:

````
fit <- stan_sample(loglik_fun, inits, additional_args = list(y),
                   lower = c(-Inf, 0), # Enforce a positivity constraint for SD
                   num_chains = 1, seed = 1234,
                   max_treedepth = 2)
````

results in

````
857 of 1000 (85.7%) transitions hit the maximum treedepth limit of 2, or 2^2 leapfrog steps.
Trajectories that are prematurely terminated due to this limit will result in slow exploration.
For optimal performance, increase this limit.
````

whereas previously it printed no warnings.

This PR is backwards compatible and passes tests locally.
