### PR TITLE
Fix minor leak

### DIFF
--- a/src/StanEstimators.cpp
+++ b/src/StanEstimators.cpp
@@ -11,12 +11,11 @@ RcppExport SEXP call_stan_(SEXP options_vector, SEXP ll_fun, SEXP grad_fun) {
   internal::grad_fun = Rcpp::Function(grad_fun);
   std::vector<std::string> options = Rcpp::as<std::vector<std::string>>(options_vector);
   int argc = 1 + options.size();
-  char** argv = new char*[argc];
+  const char* argv[argc];
 
   // Read in the name
   std::string name = "\0";
-  argv[0] = new char[name.size() + 1];
-  strcpy(argv[0], name.c_str());
+  argv[0] = name.c_str();
 
   if (options.size() > 0) {
     // internal counter
@@ -24,13 +23,10 @@ RcppExport SEXP call_stan_(SEXP options_vector, SEXP ll_fun, SEXP grad_fun) {
 
     // Read List into vector of char arrays
     for (int i = 0; i < options.size(); ++i) {
-      std::string val = std::string(options[i]);
-      argv[counter] = new char[val.size() + 1];
-      strcpy(argv[counter++], val.c_str());
+      argv[counter++] = options[i].c_str();
     }
   }
-  const char** argv2 = const_cast<const char**>(argv);
-  return Rcpp::wrap(cmdstan::command(argc, argv2));
+  return Rcpp::wrap(cmdstan::command(argc, argv));
   END_RCPP
 }
 


### PR DESCRIPTION
This PR fixes some very minor leaks:

- Instances of  `new` without corresponding `free`.
- No need to copy allocated string data to temporaries.

Note: Passes `tests/testthat.R`.
